### PR TITLE
add GetEvent to get unmarshaled data from events

### DIFF
--- a/cameras_test.go
+++ b/cameras_test.go
@@ -57,6 +57,6 @@ func Test_StreamCameraDevice(t *testing.T) {
 		t.Fatal(err)
 	}
 	event := <-c
-	assert.Equal(t, "123", event.name)
-	assert.Equal(t, "456", event.data)
+	assert.Equal(t, []byte("123"), event.name)
+	assert.Equal(t, []byte("456"), event.data)
 }

--- a/event.go
+++ b/event.go
@@ -61,18 +61,9 @@ type cameraData struct {
 	Data *device.Camera `json:"data"`
 }
 
-func prettyPrinter(eventType EventsType, v interface{}) (err error) {
-	fmt.Printf("Event type: %v\n", eventType)
-	b, err := json.MarshalIndent(v, "", "  ")
-	if err == nil {
-		fmt.Println(string(b))
-	}
-	return
-}
-
 // GetEvent returns the device data along with the type for type casting
 // Returns the device type, device id, data, error
-func (e Event) GetEvent(print bool) (EventsType, string, interface{}, error) {
+func (e Event) GetEvent() (EventsType, string, interface{}, error) {
 	if string(e.name) == string(KeepAlive) {
 		return KeepAlive, "", nil, nil
 	}
@@ -92,25 +83,18 @@ func (e Event) GetEvent(print bool) (EventsType, string, interface{}, error) {
 	switch eventType {
 	case Thermostats:
 		thermostatDataBuf := thermostatData{}
-		err = json.Unmarshal(e.data, &thermostatDataBuf)
+		json.Unmarshal(e.data, &thermostatDataBuf)
 		deviceData = thermostatDataBuf.Data
 	case SmokeCoAlarms:
 		smokeCoAlarmDataBuf := smokeCoAlarmData{}
-		err = json.Unmarshal(e.data, &smokeCoAlarmDataBuf)
+		json.Unmarshal(e.data, &smokeCoAlarmDataBuf)
 		deviceData = smokeCoAlarmDataBuf.Data
 	case Cameras:
 		cameraDataBuf := cameraData{}
-		err = json.Unmarshal(e.data, &cameraDataBuf)
+		json.Unmarshal(e.data, &cameraDataBuf)
 		deviceData = cameraDataBuf.Data
 	default:
 		return EventError, "", nil, fmt.Errorf("unhandled device type: %v", eventType)
-	}
-	if err != nil {
-		return EventError, "", nil, fmt.Errorf("data unmarshal error: %v", err)
-	}
-
-	if print {
-		prettyPrinter(eventType, deviceData)
 	}
 	return eventType, deviceID, deviceData, nil
 }
@@ -158,7 +142,6 @@ func readEvents(events chan<- Event, resp *http.Response) {
 			break
 		}
 		if err == io.EOF {
-			log.Printf("got EOF reading response: %v", err)
 			break
 		}
 

--- a/event.go
+++ b/event.go
@@ -34,7 +34,7 @@ const (
 	SmokeCoAlarms EventsType = "smoke_co_alarms"
 	Cameras       EventsType = "cameras"
 	KeepAlive     EventsType = "keep-alive"
-	EventError    EventsType = "ERROR"
+	EventError    EventsType = "error"
 )
 
 // Event represents a response when changes occur in structure or device data.

--- a/event.go
+++ b/event.go
@@ -3,13 +3,16 @@ package nest
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/jtsiros/nest/config"
+	"github.com/jtsiros/nest/device"
 )
 
 const (
@@ -22,10 +25,94 @@ var (
 	dataPfx  = []byte(data)
 )
 
+// EventsType describes the supported event types (usually based on device)
+type EventsType string
+
+// all the event types
+const (
+	Thermostats   EventsType = "thermostats"
+	SmokeCoAlarms EventsType = "smoke_co_alarms"
+	Cameras       EventsType = "cameras"
+	KeepAlive     EventsType = "keep-alive"
+	EventError    EventsType = "ERROR"
+)
+
 // Event represents a response when changes occur in structure or device data.
 type Event struct {
-	name string
-	data string
+	name []byte
+	data []byte
+}
+
+func (e Event) String() string {
+	return fmt.Sprintf("Event name: %v, Data: %v", string(e.name), string(e.data))
+}
+
+type eventPath struct {
+	Path string `json:"path"`
+}
+
+type thermostatData struct {
+	Data *device.Thermostat `json:"data"`
+}
+type smokeCoAlarmData struct {
+	Data *device.SmokeAlarm `json:"data"`
+}
+type cameraData struct {
+	Data *device.Camera `json:"data"`
+}
+
+func prettyPrinter(eventType EventsType, v interface{}) (err error) {
+	fmt.Printf("Event type: %v\n", eventType)
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err == nil {
+		fmt.Println(string(b))
+	}
+	return
+}
+
+// GetEvent returns the device data along with the type for type casting
+// Returns the device type, device id, data, error
+func (e Event) GetEvent(print bool) (EventsType, string, interface{}, error) {
+	if string(e.name) == string(KeepAlive) {
+		return KeepAlive, "", nil, nil
+	}
+
+	var eventPathBuf eventPath
+	err := json.Unmarshal(e.data, &eventPathBuf)
+	if err != nil {
+		return EventError, "", nil, fmt.Errorf("path unmarshal error: %v", err)
+	}
+
+	// /devices/thermostats/<id>
+	eventParsed := strings.Split(eventPathBuf.Path, "/")
+	deviceID := eventParsed[3]
+	eventType := EventsType(eventParsed[2])
+
+	var deviceData interface{}
+	switch eventType {
+	case Thermostats:
+		thermostatDataBuf := thermostatData{}
+		err = json.Unmarshal(e.data, &thermostatDataBuf)
+		deviceData = thermostatDataBuf.Data
+	case SmokeCoAlarms:
+		smokeCoAlarmDataBuf := smokeCoAlarmData{}
+		err = json.Unmarshal(e.data, &smokeCoAlarmDataBuf)
+		deviceData = smokeCoAlarmDataBuf.Data
+	case Cameras:
+		cameraDataBuf := cameraData{}
+		err = json.Unmarshal(e.data, &cameraDataBuf)
+		deviceData = cameraDataBuf.Data
+	default:
+		return EventError, "", nil, fmt.Errorf("unhandled device type: %v", eventType)
+	}
+	if err != nil {
+		return EventError, "", nil, fmt.Errorf("data unmarshal error: %v", err)
+	}
+
+	if print {
+		prettyPrinter(eventType, deviceData)
+	}
+	return eventType, deviceID, deviceData, nil
 }
 
 // Stream represents an open connection to the Nest APIs for device and structure changes.
@@ -87,13 +174,13 @@ func readEvents(events chan<- Event, resp *http.Response) {
 	close(events)
 }
 
-func extract(line []byte, pfx []byte) string {
+func extract(line []byte, pfx []byte) []byte {
 	if len(line) == 0 {
-		return ""
+		return nil
 	}
 	pfxIdx := len(pfx) + 1
 	endOfLineIdx := len(line) - 1
-	return string(line[pfxIdx:endOfLineIdx])
+	return line[pfxIdx:endOfLineIdx]
 }
 
 // createConnection opens an event-stream to the Nest API to receive events from devices.

--- a/event_test.go
+++ b/event_test.go
@@ -18,11 +18,11 @@ func Test_extract(t *testing.T) {
 	tt := []struct {
 		line     []byte
 		prefix   []byte
-		expected string
+		expected []byte
 	}{
-		{[]byte("data: this is my data\n"), []byte("data:"), "this is my data"},
-		{[]byte("event: update\n"), []byte("event:"), "update"},
-		{[]byte(""), []byte("event:"), ""},
+		{[]byte("data: this is my data\n"), []byte("data:"), []byte("this is my data")},
+		{[]byte("event: update\n"), []byte("event:"), []byte("update")},
+		{[]byte(""), []byte("event:"), nil},
 	}
 
 	for _, tc := range tt {
@@ -43,10 +43,10 @@ func Test_readEvents(t *testing.T) {
 	tt := []struct {
 		req                        func(http.ResponseWriter, *http.Request)
 		rec                        *httptest.ResponseRecorder
-		expectedName, expectedData string
+		expectedName, expectedData []byte
 	}{
-		{handlerSuccess, httptest.NewRecorder(), "this is an event", "this is data"},
-		{handlerEmpty, httptest.NewRecorder(), "", ""},
+		{handlerSuccess, httptest.NewRecorder(), []byte("this is an event"), []byte("this is data")},
+		{handlerEmpty, httptest.NewRecorder(), nil, nil},
 	}
 
 	for _, tc := range tt {

--- a/smokecoalarms_test.go
+++ b/smokecoalarms_test.go
@@ -50,6 +50,6 @@ func Test_StreamSmokeCoAlarmDevice(t *testing.T) {
 		t.Fatal(err)
 	}
 	event := <-c
-	assert.Equal(t, "123", event.name)
-	assert.Equal(t, "456", event.data)
+	assert.Equal(t, []byte("123"), event.name)
+	assert.Equal(t, []byte("456"), event.data)
 }

--- a/thermostats_test.go
+++ b/thermostats_test.go
@@ -266,6 +266,6 @@ func Test_StreamThermostatDevice(t *testing.T) {
 		t.Fatal(err)
 	}
 	event := <-c
-	assert.Equal(t, "123", event.name)
-	assert.Equal(t, "456", event.data)
+	assert.Equal(t, []byte("123"), event.name)
+	assert.Equal(t, []byte("456"), event.data)
 }


### PR DESCRIPTION
This adds a GetEvent method so that users can work with device types without worrying about JSON conversions and parsing the devices path.

The Event type has been modified to store bytes instead of strings, since that is what's required for unmarshaling. To help avoid exposing this change to the user a String method has also been added.

Simple example usage with exactly one device, ignoring errors:

```go
 eventType, _, data, _ := event.GetEvent(false)
 if eventType == nest.KeepAlive {
   return
 }
 mynest, _ := data.(*device.Thermostat)
 fmt.Printf("Ambient temperature:\n", mynest.AmbientTemperatureF)
```

I've really only tested this with my Nest thermostat, so it's possible I've messed something up (well, really that's always possible)!